### PR TITLE
 upgrade openapi-schema-validation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.undertow>2.1.3.Final</version.undertow>
         <versions.maven-version>2.4</versions.maven-version>
         <version.json-schema-validator>1.0.29</version.json-schema-validator>
-        <version.openapi-schema-validation>2.0.0</version.openapi-schema-validation>
+        <version.openapi-schema-validation>2.0.2</version.openapi-schema-validation>
         <version.maven-javadoc>3.1.0</version.maven-javadoc>
     </properties>
 


### PR DESCRIPTION
the openapi-schema-validation library was use light-rest-4j SNAPSHOT version.
change it to use release version
and there is a error message issue fix on the new release