### PR TITLE
Special Character Fix

### DIFF
--- a/custom-runtime/src/main/java/com/networknt/aws/lambda/HttpUtils.java
+++ b/custom-runtime/src/main/java/com/networknt/aws/lambda/HttpUtils.java
@@ -4,8 +4,13 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 public class HttpUtils {
+
+    private HttpUtils() {
+        throw new IllegalStateException("HttpUtils is a utility class");
+    }
 
     public static HttpURLConnection get(String endpoint) throws IOException {
         URL url = new URL(endpoint);
@@ -28,7 +33,7 @@ public class HttpUtils {
         connection.setDoOutput(true);
 
         DataOutputStream out = new DataOutputStream(connection.getOutputStream());
-        out.writeBytes(message);
+        out.write(message.getBytes(StandardCharsets.UTF_8));
 
         out.flush();
         out.close();


### PR DESCRIPTION
Changed method from `writeBytes` to `write` to avoid mangling accent characters.